### PR TITLE
ignore dev files in release

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,7 @@ tests export-ignore
 .gitignore export-ignore
 .php-cs-fixer.dist.php export-ignore
 Makefile export-ignore
+composer.lock export-ignore
 phpstan.neon export-ignore
 phpunit.xml export-ignore
 rector.php export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,10 @@
 *.php text eol=lf
+.github export-ignore
+tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.php-cs-fixer.dist.php export-ignore
+Makefile export-ignore
+phpstan.neon export-ignore
+phpunit.xml export-ignore
+rector.php export-ignore


### PR DESCRIPTION
A small change, which will prevent multiple DEV related files from being included in the composer release.

These files shouldn't be in there actually, as they are not relevant for a production release.

Right now this is what I have in `vendor/`:
![image](https://github.com/user-attachments/assets/45ffa1f6-0ab6-4272-902e-aea144e685b9)

